### PR TITLE
Fix noreferrer attribute typo

### DIFF
--- a/components/Items.tsx
+++ b/components/Items.tsx
@@ -48,7 +48,7 @@ export function Items({ items, label, link = false }: any) {
               key={i}
               href={link ? item.href : ""}
               target="_blank"
-              rel="no refferer"
+              rel="noreferrer"
             >
               <Item item={item} link={link} index={i} arrLength={arr.length} />
             </Link>


### PR DESCRIPTION
## Summary
- fix typo in `Link` element rel attribute

## Testing
- `yarn install` *(fails: tunneling socket could not be established)*
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6840782f60d08333b83d3f38eb8e5e53